### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2410.02745-red?logo=arxiv" height="14" />  [AVG-LLaVA: A Large Multimodal Model with Adaptive Visual Granularity](https://arxiv.org/pdf/2410.02745) .[AVG-LLaVA;[Github](https://github.com/DeepLearnXMU/AVG-LLaVA)]
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2409.10994-red?logo=arxiv" height="14" />  [Less is More: A Simple yet Effective Token Reduction Method for Efficient Multi-modal LLMs](https://arxiv.org/pdf/2409.10994) .[TRIM]
+-  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2409.03206-red?logo=arxiv" height="14" />  [TC-LLaVA: Rethinking the Transfer from Image to Video Understanding with Temporal Consideration](https://arxiv.org/pdf/2409.03206) .[TC-LLaVA;Video;]
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2409.09564-red?logo=arxiv" height="14" />  [TG-LLaVA: Text Guided LLaVA via Learnable Latent Embeddings](https://arxiv.org/pdf/2409.09564) .[TG-LLaVA]
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2409.03420-red?logo=arxiv" height="14" />  [mPLUG-DocOwl2: High-resolution Compressing for OCR-free Multi-page Document Understanding](https://arxiv.org/abs/2409.03420) .    [mPLUG-DocOwl2;[Github](https://github.com/X-PLUG/mPLUG-DocOwl)]
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2409.01156-red?logo=arxiv" height="14" />  [TempMe: Video Temporal Token Merging for Efficient Text-Video Retrieval](https://arxiv.org/pdf/2409.01156) .    [TempMe;Video;[Github](https://github.com/X-PLUG/mPLUG-DocOwl)]


### PR DESCRIPTION
重新思考从图像到视频理解的迁移，并考虑时间因素

将图像预训练的 MLLMs 适应于与视频相关的任务。 

在本文中，我们提出了两种策略，通过改进 LLMs 中的层间注意力计算来增强模型在视频理解任务中的能力。 具体而言，第一种方法侧重于使用时间感知双 RoPE 来增强旋转位置嵌入 (RoPE)，它引入了时间位置信息以增强 MLLM 的时间建模能力，同时保留视觉和文本符元的相对位置关系。 第二种方法涉及使用帧级块因果注意力掩码来增强注意力掩码，这是一种简单而有效的方法，它扩展了视频帧内和跨帧的视觉符元交互，同时保持因果推理机制。 基于这些提出的方法，我们将 LLaVA 调整为视频理解任务，将其命名为时间考虑的 LLaVA (TC-LLaVA)。 我们的 TC-LLaVA 在各种视频理解基准测试中取得了新的最先进的性能，仅在与视频相关的 datasets 上进行监督微调 (SFT)。