### PR TITLE
adding two recent works in openreview of  ICLR2025  submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 🔥🔥🔥 A paper list of some recent  works about Token Compress for Vit and VLM.
 ## VLM
 ### 2024
+- OpenReview [LVP: Language-guide Visual Projector for Efficient Multimodal LLM](https://openreview.net/pdf?id=PxBzxO02Ef).[LVP]
+- OpenReview [Efficient Multi-modal Large Language Models via Visual Token Grouping](https://openreview.net/pdf?id=ym1dS37mZE) .[VisToG]
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2411.15024-red?logo=arxiv" height="14" />  [DyCoke:Dynamic Compression of Tokens for Fast Video Large Language Models](https://arxiv.org/pdf/2411.15024) .[DyCoke;Video;[Github](https://github.com/KD-TAO/DyCoke)]
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2411.14228-red?logo=arxiv" height="14" />  [FocusLLaVA: A Coarse-to-Fine Approach for Efficient and Effective Visual Token Compression](https://arxiv.org/pdf/2411.14228) .[FocusLLaVA;]
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2411.10803-red?logo=arxiv" height="14" />  [MustDrop:Multi-Stage Vision Token Dropping: Towards Efficient Multimodal Large Language Model](https://arxiv.org/pdf/2411.10803) .[MustDrop;[Github](https://github.com/liuting20/MustDrop)]


### PR DESCRIPTION
I found two latest works in OpenReview submitted to ICLR 2025. The one is LVP, which introduces a language-guided approach for token compression. Another one is VisToG, which presents a grouping mechanism to group similar image segments from pretrained vision encoders.