### PR TITLE
Add HiPrune

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ## VLM
 ### 2025
 
+- <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2508.00553-red?logo=arxiv" height="14" /> [HiPrune: Training-Free Visual Token Pruning via Hierarchical Attention in Vision-Language Models](https://arxiv.org/abs/2508.00553). [HiPrune; [GitHub](https://github.com/Danielement321/HiPrune)]
+
 - <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2508.01548-red?logo=arxiv" height="14" /> [A Glimpse to Compress: Dynamic Visual Token Pruning for Large Vision-Language Models](https://arxiv.org/pdf/2508.01548). [GlimpsePrune; [GitHub](https://github.com/HVision-NKU/GlimpsePrune)]
 
 - <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2507.23362-red?logo=arxiv" height="14" /> [Short-LVLM: Compressing and Accelerating Large


### PR DESCRIPTION
Hello, thanks for your awesome work!
We are going to introduce our work HiPrune, a training-free method for VLM token pruning. HiPrune prunes visual tokens under guidance of the attention from vision encoder, and is totally training-free and model-agnostic. Like most methods in this paper list, we carry out experiments on LLaVA-1.5 (w/192, 128, and 64 visual tokens), LLaVA-NeXT (w/640, 320, 160 visual tokens), and Qwen2.5-VL (w/ 33.3%, 22.2%, and 11.1% visual tokens).
In addition, we carry out a series of studies across multiple vision encoders and conclude a universal attention distribution rule, which might be helpful for following works.
Thanks again for your work and we hope that our paper can be added!