### PR TITLE
Kind request for adding AutoPrune (NIPS 2025)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2511.00141-red?logo=arxiv" height="14" /> [FloC: FACILITY LOCATION-BASED EFFICIENT VI- SUAL TOKEN COMPRESSION FOR LONG VIDEO UN- DERSTANDING](https://arxiv.org/pdf/2511.00141). [FloC;]
 
 - <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2510.16598-red?logo=arxiv" height="14" /> [VisionSelector: End-to-End Learnable Visual Token Compression for Efficient Multimodal LLMs](https://arxiv.org/pdf/2510.16598). [VisionSelector; [GitHub](https://github.com/JulietChoo/VisionSelector)]
+- <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2509.23931-red?logo=arxiv" height="14" /> [AutoPrune: Each Complexity Deserves a Pruning Policy](https://arxiv.org/abs/2509.23931). [AutoPrune;NIPS2025; [GitHub](https://github.com/AutoLab-SAI-SJTU/AutoPrune)]
 
 - <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2509.00419-red?logo=arxiv" height="14" /> [LightVLM: Acceleraing Large Multimodal Models with Pyramid Token Merging and KV Cache Compression](https://arxiv.org/pdf/2509.00419). [LightVLM;]
 


### PR DESCRIPTION
I would like to kindly request that you add our recent work to your collection:

Paper: AutoPrune: Each Complexity Deserves a Pruning Policy
ArXiv: https://arxiv.org/abs/2509.23931
Code: https://github.com/AutoLab-SAI-SJTU/AutoPrune

In this paper, we present AutoPrune, a training free plug and play framework that adapts token pruning to sample and task complexity by mapping mutual information to a budget constrained logistic retention curve, achieving up to 89% visual token removal and 76.8% FLOPs reduction on LLaVA-1.5-7B while retaining 96.7% accuracy on average.

Thank you for your time and consideration!

