### PR TITLE
Add new research papers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 ### 2026
 
+- <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2604.00086-red?logo=arxiv" height="14" /> [Hierarchical Pre-Training of Vision Encoders with Large Language Models](https://arxiv.org/pdf/2604.00086). [HIVE;CVPR 2026 Workshop;[GitHub](https://github.com/eugenelet/HIVE)]
+
+- <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2603.26775-red?logo=arxiv" height="14" /> [Learning to Select Visual In-Context Demonstrations](https://arxiv.org/pdf/2603.26775). [LSD;CVPR 2026 Findings;[GitHub](https://github.com/eugenelet/Learning-to-Select-Visual-In-Context-Demonstrations)]
+
+- [Semantic-Guided Slow-Fast Pruning of Visual Tokens for Vision-Language Models](https://ieeexplore.ieee.org/abstract/document/11460400). [ICASSP 2026]
+
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2607.12500-red?logo=arxiv" height="14" /> [Attention-Free and Lightweight Token Reduction for Efficient Vision-Language Models](https://arxiv.org/pdf/2607.13500). [ALTR;]
 
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2607.12756-red?logo=arxiv" height="14" /> [VisCo: Leveraging Large Language Models as Intrinsic Encoders for Visual Token Compression](https://arxiv.org/pdf/2607.12756). [VisCo;ACM MM 2026;[GitHub](https://github.com/Zyvpeng/VisCo/tree/main)]


### PR DESCRIPTION
Hi @daixiangzi,

Thank you for maintaining this awesome repository! I would like to suggest adding three recent papers on visual token pruning, hierarchical vision-language pre-training, and visual in-context demonstration selection to the 2026 list:

1. **Hierarchical Pre-Training of Vision Encoders with Large Language Models (HIVE)**
   - **Venue:** CVPR 2026 (5th MMFM Workshop)
   - **Links:** [arXiv](https://arxiv.org/abs/2604.00086) | [Paper](https://openaccess.thecvf.com/content/CVPR2026W/MMFM5/papers/Lee_Hierarchical_Pre-Training_of_Vision_Encoders_with_Large_Language_Model_CVPRW_2026_paper.pdf) | [GitHub](https://github.com/eugenelet/HIVE)
   - **Authors:** Eugene Lee, Ting-Yu Chang, Jui-Huang Tsai, Jiajie Diao, Chen-Yi Lee

2. **Learning to Select Visual In-Context Demonstrations (LSD)**
   - **Venue:** CVPR 2026 (Findings)
   - **Links:** [arXiv](https://arxiv.org/abs/2603.26775) | [Paper](https://openaccess.thecvf.com/content/CVPR2026F/papers/Lee_Learning_to_Select_Visual_In-Context_Demonstrations_CVPRF_2026_paper.pdf) | [GitHub](https://github.com/eugenelet/Learning-to-Select-Visual-In-Context-Demonstrations)
   - **Authors:** Eugene Lee, Yu-Chi Lin, Jiajie Diao

3. **Semantic-Guided Slow-Fast Pruning of Visual Tokens for Vision-Language Models**
   - **Venue:** ICASSP 2026
   - **Links:** [IEEE Xplore](https://ieeexplore.ieee.org/abstract/document/11460400)
   - **Authors:** Zi-Wei Liu, Eugene Lee, Jui-Huang Tsai, Jiajie Diao, Chen-Yi Lee

---

### Summary of Changes
- Added entries to `README.md` under `## VLM` -> `### 2026`.
- Positioned entries according to arXiv reverse-chronological order.