### PR TITLE
Add 3DZip (ECCV 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ### 2026
 
+-  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2608.01185-red?logo=arxiv" height="14" /> [3DZip: Spatial-Aware Feature Diversity-Guided Token Compression for 3D Question Answering](https://arxiv.org/pdf/2608.01185). [3DZip;3D;ECCV 2026;[GitHub](https://github.com/cvsp-lab/3DZip)]
+
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2607.12500-red?logo=arxiv" height="14" /> [Attention-Free and Lightweight Token Reduction for Efficient Vision-Language Models](https://arxiv.org/pdf/2607.13500). [ALTR;]
 
 -  <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2607.12756-red?logo=arxiv" height="14" /> [VisCo: Leveraging Large Language Models as Intrinsic Encoders for Visual Token Compression](https://arxiv.org/pdf/2607.12756). [VisCo;ACM MM 2026;[GitHub](https://github.com/Zyvpeng/VisCo/tree/main)]


### PR DESCRIPTION
Adding our paper to the VLM / 2026 list, following the existing format:

**3DZip: Spatial-Aware Feature Diversity-Guided Token Compression for 3D Question Answering** (ECCV 2026)
- arXiv: https://arxiv.org/abs/2608.01185
- Code: https://github.com/cvsp-lab/3DZip
- Project page: https://paper.pnu-cvsp.com/3DZip/

A training-free, three-stage token compression framework for 3D vision-language models (voxelization → DPP diversity selection → spatially-constrained merging). Thanks for maintaining this great list!