### PR TITLE
Add RESTORE (ICML 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Large Language Models](https://arxiv.org/pdf/2606.02161). [InfoMerge; ]
 - <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2606.01756-red?logo=arxiv" height="14" /> [EvoCut: Multi-Layer Evolution-Aware Visual Token Compression for
 Efficient Large Vision-Language Models](https://arxiv.org/pdf/2606.01756). [EvoCut; ]
 
+- <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2606.01711-red?logo=arxiv" height="14" /> [RESTORE: Improving Visual Token Reduction via Rectifying Distortions for Efficient Multimodal LLM Inference](https://arxiv.org/abs/2606.01711). [RESTORE; ICML 2026; [GitHub](https://github.com/cvlab-yonsei/RESTORE)]
+
 - <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2605.30010-red?logo=arxiv" height="14" /> [EarlyTom:Early Token Compression Completes Fast Video Understanding](https://arxiv.org/pdf/2605.30010). [EarlyTom;Video;CVPR 2026;[GitHub](https://viridisgreen.github.io/EarlyTom/)]
 
 - <img alt="arXiv" src="https://img.shields.io/badge/arXiv-2605.29657-red?logo=arxiv" height="14" /> [OccamToken: Efficient VLM Inference with


### PR DESCRIPTION
Adding a paper, following the existing format and order (newest first)

Paper: Improving Visual Token Reduction via Rectifying Distortions for Efficient Multimodal LLM Inference
arXiv: https://arxiv.org/abs/2606.01711
Code: https://github.com/cvlab-yonsei/RESTORE

In this work, the authors propose RESTORE, a novel framework that rectifies positional and attentional distortions overlooked in existing visual token reduction methods, featuring distance-aware attention calibration and a distinctive anchor token selection strategy to improve accuracy while maintaining MLLM inference efficiency.

Thank you for your effort!